### PR TITLE
fix: UART2 Hack

### DIFF
--- a/src/registers/system/system.c
+++ b/src/registers/system/system.c
@@ -101,5 +101,5 @@ void SYSTEM_Initialize(void) {
     DMA_Initialize();
 
     LIGHT_RGB(0, 20, 0);
-    UART_ClearBuffer(U1SELECT);
+    UART_ClearBuffer(U2SELECT);
 }

--- a/src/states.c
+++ b/src/states.c
@@ -9,7 +9,7 @@
  * @return STATE_STANDBY or STATE_RUNCOMMAND
  */
 state_t Standby(void) {
-    if (UART_IsRxReady(U1SELECT)) {
+    if (UART_IsRxReady(U2SELECT)) {
         return STATE_RUNCOMMAND;
     } else {
         WATCHDOG_TimerClear();


### PR DESCRIPTION
Tried fixing the UART2 hack firmware.
Although I don't have the correct tools to test this (since the only way I can test is using the ESP01 chip), it did seem to me that the _PSLab_ device responded to the commands once when I was testing.
Since I need to narrow down whether the issue is with the firmware or with the ESP01, @bessman could you please test if this hack works now or not?
Also, a general small observation, I tried to write something to UART2 each time the _PSLab_ device is initialised. I observed that the data is written successfully on UART2 and I can read it each time the device initialises (turns ON or the reset button is pressed).
I did this by using the `UART2_WriteInt` function in the `SYSTEM_Initialize` function in system.c.
Thanks.